### PR TITLE
bfloat16 initial support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = "Carlo Lucibello"
 version = "0.2.0"
 
 [deps]
+BFloat16s = "ab4f0b2a-ad5b-11e8-123f-65d77653426b"
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -32,6 +33,7 @@ Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 TsunamiEnzymeExt = "Enzyme"
 
 [compat]
+BFloat16s = "0.5.0"
 BSON = "0.3.6"
 ChainRulesCore = "1"
 Compat = "4.16"

--- a/src/Tsunami.jl
+++ b/src/Tsunami.jl
@@ -1,6 +1,7 @@
 module Tsunami
 
 using Base: @kwdef, PkgId, UUID
+using BFloat16s: BFloat16
 using BSON: BSON
 using ChainRulesCore: ChainRulesCore
 using Compat: @compat

--- a/src/foil.jl
+++ b/src/foil.jl
@@ -15,7 +15,8 @@ FOIL_CONSTRUCTOR_ARGS ="""
     (see `MLDataDevices.gpu_device` documentation). 
     Default: `nothing`.
 
-- **precision**: Supports passing different precision types `(:f16, :f32, :f64)`.
+- **precision**: Supports passing different precision types `(:bf16, :f16, :f32, :f64)`, 
+    where `:bf16` is BFloat16, `:f16` is Float16, `:f32` is Float32, and `:f64` is Float64.
     Default: `:f32`.
 """
 
@@ -44,12 +45,14 @@ function Foil(;
 
     fprec = if precision == :f16
                 f16
+            elseif precision == :bf16
+                bf16
             elseif precision == :f32
                 f32
             elseif precision == :f64
                 f64
             else
-                throw(ArgumentError("precision must be one of :f16, :f32, :f64"))
+                throw(ArgumentError("precision must be one of :bf16, :f16, :f32, :f64"))
             end
 
     return Foil(device, fprec, precision) 
@@ -58,6 +61,9 @@ end
 function Base.show(io::IO, foil::Foil)
     print(io, "Foil($(foil.device), $(foil.precision))")
 end
+
+# TODO: remove this when https://github.com/FluxML/Flux.jl/issues/2573
+bf16(x) = Flux._paramtype(BFloat16, x)
 
 function select_device(accelerator::Symbol, idx_devices)
     if accelerator == :cpu

--- a/test/trainer.jl
+++ b/test/trainer.jl
@@ -148,3 +148,13 @@ end
     @test res["a"] == 1
     @test res["b"] == 2.0
 end
+
+@testitem "precision bf16" setup=[TsunamiTest] begin
+    using .TsunamiTest
+    model = TestModule1()
+    nx, ny = io_sizes(model)
+    train_dataloader = make_dataloader(nx, ny)
+    trainer = Trainer(max_epochs=2, precision=:bf16)
+    Tsunami.fit!(model, trainer, train_dataloader)
+    # TODO test properly
+end


### PR DESCRIPTION
Fix #69 

Support here is just a stub, in practice on cpu besides being slow it also produces very large losses on the examples I tried. 

See https://github.com/FluxML/Flux.jl/issues/2573 and related issue for the status of BFloat16 support in Flux.